### PR TITLE
Fix parsing form-data with array data

### DIFF
--- a/src/Http.php
+++ b/src/Http.php
@@ -488,6 +488,7 @@ class Http
             unset($boundary_data_array[0]);
         }
         $key = -1;
+        $post_encode_string = '';
         foreach ($boundary_data_array as $boundary_data_buffer) {
             list($boundary_header_buffer, $boundary_value) = \explode("\r\n\r\n", $boundary_data_buffer, 2);
             // Remove \r\n from the end of buffer.
@@ -512,7 +513,7 @@ class Http
                         else {
                             // Parse $_POST.
                             if (\preg_match('/name="(.*?)"$/', $header_value, $match)) {
-                                $_POST[$match[1]] = $boundary_value;
+                                $post_encode_string .= urlencode($match[1]) . '=' . urlencode($boundary_value) . '&';
                             }
                         }
                         break;
@@ -521,6 +522,9 @@ class Http
                         $_FILES[$key]['file_type'] = \trim($header_value);
                         break;
                 }
+            }
+            if($post_encode_string) {
+                \parse_str($post_encode_string, $_POST);
             }
         }
     }


### PR DESCRIPTION
Currently when posting data containing array, e.g.
```
-----------------------------8387567432779839952973002835
Content-Disposition: form-data; name="options[]"

a
-----------------------------8387567432779839952973002835
Content-Disposition: form-data; name="options[]"

b
-----------------------------8387567432779839952973002835
Content-Disposition: form-data; name="options[]"

c
```
it will be phrased into `$_POST['options[]']='c'` while the correct behavior should be `$_POST['options'] = ['a', 'b', 'c'];`

This PR fixes this issue by following [existing solution in workerman](https://github.com/walkor/workerman/blob/a2d7b5bc1ba2e01abcbf24fe78212798956b94b6/src/Protocols/Http/Request.php#L539-L544)


Ultimately, I suggest to move the overlapping part of `Http` to the implementation of `Workerman`.