### PR TITLE
Use random_bytes instead of mt_rand for sessionCreateId

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -115,9 +115,7 @@ trait Session
      */
     public static function sessionCreateId(): string
     {
-        \mt_srand();
-
-        return \bin2hex(\pack('d', \hrtime(true)).\pack('N', \mt_rand(0, 2147483647)));
+        return \bin2hex(\pack('d', \hrtime(true)).\random_bytes(8));
     }
 
     /**


### PR DESCRIPTION
According to https://www.php.net/manual/function.mt-rand.php, mt_rand "must not be used for cryptographic purposes". But according to the source code: https://github.com/php/php-src/blob/e72b6f471aaabafc35ee5f7e1259ebd441da7d66/ext/random/engine_mt19937.c#L240 the default seed is generated by random_bytes, so it is secure to use mt_rand together with mt_srand. However, since mt_srand uses random_bytes, it makes more sense to just use random_bytes instead, which is secure according to the documentation without need to investigate the source code.

This commit also makes the session ID longer to contain more entropy.

`mt_srand` uses 4 random bytes instead of 8, so if this little performance is required we can also change to `random_bytes(4)` instead.

See also: https://github.com/walkor/workerman/commit/c2dde2e04a8f973818b4fdbc124a3be8e8945094