### PR TITLE
testing: server port 8080 -> 18080

### DIFF
--- a/tests/AdaptermanServer.php
+++ b/tests/AdaptermanServer.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 Adapterman::init();
 
-$worker = new Worker('http://0.0.0.0:8080');
+$worker = new Worker('http://0.0.0.0:18080');
 $worker->name  = "Adapterman Tests";
 //$worker->count = 2;
 

--- a/tests/Feature/RequestHeadersTest.php
+++ b/tests/Feature/RequestHeadersTest.php
@@ -48,6 +48,6 @@ it('get headers', function (string $key, string $value) {
         ->toBe($value);
 
 })->with([
-    ['Host', '127.0.0.1:8080'],
+    ['Host', '127.0.0.1:18080'],
     ['User-Agent', 'Testing/1.0']
 ]);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -46,7 +46,7 @@ expect()->extend('toBeOne', function () {
 function HttpClient(): Client
 {
     return new Client([
-        'base_uri' => 'http://127.0.0.1:8080',
+        'base_uri' => 'http://127.0.0.1:18080',
         'headers' => [
             'User-Agent' => 'Testing/1.0',
         ],

--- a/tests/Servers/Adapterman.php
+++ b/tests/Servers/Adapterman.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 
 Adapterman::init();
 
-$worker = new Worker('http://0.0.0.0:8080');
+$worker = new Worker('http://0.0.0.0:18080');
 $worker->name  = "Adapterman Tests";
 //$worker->count = 2;
 

--- a/tests/Servers/PhpCli.php
+++ b/tests/Servers/PhpCli.php
@@ -1,6 +1,6 @@
 <?php
 
-// php -S localhost:8080 xxx.php
+// php -S localhost:18080 xxx.php
 
 // HTTP methods
 const AVAILABLE_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'];

--- a/tests/Servers/Workerman.php
+++ b/tests/Servers/Workerman.php
@@ -9,7 +9,7 @@ use Workerman\Worker;
 
 require __DIR__.'/../../vendor/autoload.php';
 
-$worker = new Worker('http://0.0.0.0:8080');
+$worker = new Worker('http://0.0.0.0:18080');
 $worker->name = 'Workerman Tests';
 
 $worker->onMessage = function (TcpConnection $connection, Request $request) {


### PR DESCRIPTION
On local machines of developers, port 8080 is often occupied by web servers or other software.
Therefore, the new port will be more convenient.